### PR TITLE
Allow volzet text

### DIFF
--- a/_data/kampen.yml
+++ b/_data/kampen.yml
@@ -43,7 +43,8 @@
   leeftijd_kort: 9-12 jaar
   img: assets/images/kampen/nano.jpeg
   locatie: laiterie
-  form_id: kamp_zomer
+  form_id: # kamp_zomer
+  form_button_text: Kamp volzet
     
 
 - name: GIGA
@@ -59,7 +60,8 @@
   img: assets/images/kampen/giga.jpg
   img_mobile: assets/images/kampen/giga_mobile.jpg
   locatie: laiterie
-  form_id: kamp_zomer
+  form_id: # kamp_zomer
+  form_button_text: Kamp volzet
 
 
 - name: MEGA - op de fiets

--- a/_includes/camp-info.html
+++ b/_includes/camp-info.html
@@ -28,6 +28,9 @@
 {% endcapture %}
 
 
+{% assign call_to_action = include.form_button_text | default: "Schrijf je in!" %}
+{% assign call_to_action_disabled = include.form_button_text | default: "Inschrijvingen nog gesloten" %}
+
 {% if include.type == 'left' %}
     {% include section-img-left.html
         title=include.title
@@ -36,8 +39,8 @@
         img_mobile=include.img_mobile
         img_list=include.img_list
         img_list_mobile=include.img_list_mobile
-        call_to_action="Schrijf je in!"
-        call_to_action_disabled="Inschrijvingen nog gesloten"
+        call_to_action=call_to_action
+        call_to_action_disabled=call_to_action_disabled
         url=form_item.link %}
 {% else %}
     {% include section-img-right.html
@@ -47,7 +50,7 @@
         img_mobile=include.img_mobile
         img_list=include.img_list
         img_list_mobile=include.img_list_mobile
-        call_to_action="Schrijf je in!"
-        call_to_action_disabled="Inschrijvingen nog gesloten"
+        call_to_action=call_to_action
+        call_to_action_disabled=call_to_action_disabled
         url=form_item.link %}
 {% endif %}

--- a/op-kamp.html
+++ b/op-kamp.html
@@ -68,6 +68,7 @@ kampen? Bekijk hieronder dan zeker ons aanbod!
         img_list_mobile=item.img_list_mobile
         locatie=item.locatie
         form_id=item.form_id
+        form_button_text=item.form_button_text
         type=type  %}
 
 {% endfor %}


### PR DESCRIPTION
NANO en GIGA zijn volzet. 

Optie toegevoegd om dit ook op de site te werspiegelen. 

Indien er geen `form_id` (in `kampen.yml`) of  overeenkomstige `link` (in `forms.yml`) gedefinieerd zijn, kwam de inschrijfknop sowieso al grijs en niet klikbaar, met de tekst "Inschrijvingen nog gesloten". 

Ineens toegevoegd dat je nu per kamp in `kampen.yml` ook een `form_button_text` kan meegeven, die gebruikt kan worden om de tekst op de inschrijfknop bij een kamp (disabled of niet) te overschrijven met je eigen tekst, in dit geval allebei "Kamp volzet". 


![image](https://github.com/user-attachments/assets/13a6c643-fed6-43bd-bc22-9cc9c19c59fe)
